### PR TITLE
[VIAJANDO-17] Add search trip endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -604,6 +604,11 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
+    "geolib": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/geolib/-/geolib-3.3.1.tgz",
+      "integrity": "sha512-sfahBXFcgELdpumDZV5b3KWiINkZxC5myAkLk067UUcTmTXaiE9SWmxMEHztn/Eus4JX6kesHxaIuZlniYgUtg=="
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "body-parser": "^1.19.0",
     "cors": "^2.8.5",
     "express": "^4.17.1",
+    "geolib": "^3.3.1",
     "jsonwebtoken": "^8.5.1",
     "moment": "^2.27.0",
     "pg": "^8.3.0",

--- a/src/controllers/trips.controller.ts
+++ b/src/controllers/trips.controller.ts
@@ -3,7 +3,6 @@ import bodyParser from 'body-parser';
 import { TripsSerivce } from '../services/Trips.service';
 import { Auth } from '../guardians/auth';
 import { ParamsHelper } from '../helper/params.helper';
-import { GeneralHelper } from '../helper/general.helper';
 import { ORMHelper } from '../helper/orm.helper';
 
 class TripsController {
@@ -16,12 +15,12 @@ class TripsController {
     private tripsService = new TripsSerivce();
 
     private paramsHelper = new ParamsHelper();
-    private generalHelper = new GeneralHelper();
     private ormHelper = new ORMHelper();
 
     private init() {
         this.router.get('/', this.jsonParser, this.auth.authenticateToken, this.paramsHelper.validateParams, (req: any, res: Response) => this.getTripById(req, res));
         this.router.post('/', this.jsonParser, this.auth.authenticateToken, this.paramsHelper.validateParams, (req: any, res: Response) => this.createTrip(req, res));
+        this.router.get('/search_trip', this.jsonParser, this.auth.authenticateToken, this.paramsHelper.validateParams, (req: any, res: Response) => this.searchTrip(req, res));
     }
 
     private async getTripById(req: any, res: Response) {
@@ -44,6 +43,17 @@ class TripsController {
         catch (e) {
             return res.status(400).json({ error: e });
         };
+    }
+
+    private async searchTrip(req: any, res: Response) {
+        try {
+            console.log(req.query);
+            const params = await this.ormHelper.searchTripParams(req.query);
+            const trips = await this.tripsService.getTripsByLatitude(params);
+            return res.json({ trips });
+        } catch (e) {
+            return res.json({ error: e });
+        }
     }
 
     constructor() {

--- a/src/entity/Trips.ts
+++ b/src/entity/Trips.ts
@@ -31,10 +31,16 @@ export class Trips {
     passenger_amount: number;
 
     @Column()
-    from: string;
+    from_lat: number;
 
     @Column()
-    to: string;
+    from_lng: number;
+
+    @Column()
+    to_lat: number;
+
+    @Column()
+    to_lng: number;
 
     @Column()
     city_name: string;

--- a/src/helper/geolocation.helper.ts
+++ b/src/helper/geolocation.helper.ts
@@ -1,0 +1,16 @@
+import { computeDestinationPoint, getBounds } from 'geolib';
+
+export class GeolocationHelper {
+
+  constructor () {}
+
+  public async getBoundLocation(latitude: number, longitude: number, range: number) {
+    const rangeInMeters = range * 1000;
+    const a0   = await computeDestinationPoint( { latitude, longitude }, rangeInMeters, 0   );
+    const b90  = await computeDestinationPoint( { latitude, longitude }, rangeInMeters, 90  );
+    const c180 = await computeDestinationPoint( { latitude, longitude }, rangeInMeters, 180 );
+    const d360 = await computeDestinationPoint( { latitude, longitude }, rangeInMeters, 360 );
+    return getBounds([ a0, b90, c180, d360 ]);
+  }
+
+}

--- a/src/helper/params.helper.ts
+++ b/src/helper/params.helper.ts
@@ -4,7 +4,8 @@ import { Params } from "../models/params.model";
 export class ParamsHelper {
 
   public validateParams(req: Request, res: Response, next: NextFunction) {
-    const requiredParams: any = Params[req.method][req.baseUrl];
+    const url = req.originalUrl.split('?');
+    const requiredParams: any = Params[req.method][url[0]];
     const params = req.method === 'GET' ? req.query : req.body;
     // tslint:disable-next-line: no-shadowed-variable
     const validateParams = (params: any, requiredParams: any) => {

--- a/src/models/params.model.ts
+++ b/src/models/params.model.ts
@@ -2,6 +2,15 @@ export const Params: { [k: string]: any } = Object.freeze({
   'GET': {
     '/api/v1/users': { email: 'string', password: 'string' },
     '/api/v1/trips': { id: 'string' },
+    '/api/v1/trips/search_trips': {
+      from_lat: 'string',
+      from_lng: 'string',
+      range: 'string',
+      to_lat: 'string',
+      to_lng: 'string',
+      start_on: 'string',
+      end_on: 'string'
+    },
     '/api/v1/cars': { id: 'string' }
   },
   'POST': {
@@ -9,8 +18,10 @@ export const Params: { [k: string]: any } = Object.freeze({
       driver_id: 'number',
       car_id: 'number',
       passenger_ammount: 'number',
-      from: 'string',
-      to: 'string',
+      from_lat: 'number',
+      from_lng: 'number',
+      to_lat: 'number',
+      to_lng: 'number',
       city_name: 'string',
       price: 'number',
       start_on: 'string',

--- a/src/services/Trips.service.ts
+++ b/src/services/Trips.service.ts
@@ -1,4 +1,4 @@
-import { getConnection } from "typeorm";
+import { getConnection, MoreThan, Not, Between } from "typeorm";
 import { Trips, Status } from "../entity/Trips";
 import telkit from 'terminal-kit';
 
@@ -15,6 +15,15 @@ export class TripsSerivce {
   public async createTrip(trip: any) {
     try {
       return await getConnection().manager.save(trip);
+    } catch (e) {
+      telkit.terminal(e);
+      return e;
+    }
+  }
+
+  public async getTripsByLatitude(params: any) {
+    try {
+      return await getConnection().manager.getRepository(Trips).find({ ...params })
     } catch (e) {
       telkit.terminal(e);
       return e;


### PR DESCRIPTION
How this endpoint works? 
We send from_lat, from_lng (latitude and longitude) & range (max radio of search) as strings, it converts them into Number then we do directionals search East, West, South, North (that's why 0°, 90°, 180°, 360°, imagine this as a clock) having those latitudes and longs we can create a spectrum of the max lat & min lat (as well that max and min long) then is just compare to our DB which latitude and longitude matches with this spectrum
We do the same for the "to" (it means arrival coordinates)
with that we can match the departure and arrival coordinates, we only need to set the dates and retrieve the matches